### PR TITLE
autocommit being on prevents django model from being used inside a transaction. 

### DIFF
--- a/architect/databases/utilities.py
+++ b/architect/databases/utilities.py
@@ -4,8 +4,6 @@ from datetime import date, datetime, timedelta
 class Database(object):
     """Provides helpers for query execution via database cursor"""
     def __init__(self, cursor):
-        if not cursor.connection.autocommit:
-            cursor.connection.autocommit = True
         self.cursor = cursor
 
     def execute(self, sql):


### PR DESCRIPTION
before this change I would get ```ProgrammingError: autocommit cannot be used inside a transaction```
when I used ```with transaction.atomic():```

This might need to be a setting of some sort, also might want to put some comments into the reasoning it is turned on by default.