### PR TITLE
Fix: Initializing sqlite with `architect` causes PartitionTypeError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,66 +6,59 @@ python:
   - 3.3
   - 3.4
 env:
-  - PEEWEE='peewee>=2.2.0,<2.3.0' DB=postgresql
-  - PEEWEE='peewee>=2.2.0,<2.3.0' DB=mysql
-  - PEEWEE='peewee>=2.3.0,<2.4.0' DB=postgresql
-  - PEEWEE='peewee>=2.3.0,<2.4.0' DB=mysql
-  - PEEWEE='peewee>=2.4.0,<2.5.0' DB=postgresql
-  - PEEWEE='peewee>=2.4.0,<2.5.0' DB=mysql
-  - PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=postgresql
-  - PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=mysql
-  - PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=postgresql
-  - PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=mysql
-  - SQLALCHEMY='sqlalchemy>=0.8.0,<0.9.0' DB=postgresql
-  - SQLALCHEMY='sqlalchemy>=0.8.0,<0.9.0' DB=mysql
-  - SQLALCHEMY='sqlalchemy>=0.9.0,<0.10.0' DB=postgresql
-  - SQLALCHEMY='sqlalchemy>=0.9.0,<0.10.0' DB=mysql
-  - DJANGO='django>=1.4.0,<1.5.0' DB=postgresql
-  - DJANGO='django>=1.4.0,<1.5.0' DB=mysql
-  - DJANGO='django>=1.5.0,<1.6.0' DB=postgresql
-  - DJANGO='django>=1.5.0,<1.6.0' DB=mysql
-  - DJANGO='django>=1.6.0,<1.7.0' DB=postgresql
-  - DJANGO='django>=1.6.0,<1.7.0' DB=mysql
-  - DJANGO='django>=1.7.0,<1.8.0' DB=postgresql
-  - DJANGO='django>=1.7.0,<1.8.0' DB=mysql
+  - PEEWEE='peewee>=2.2,<2.2.99' DB=postgresql
+  - PEEWEE='peewee>=2.2,<2.2.99' DB=mysql
+  - PEEWEE='peewee>=2.3,<2.3.99' DB=postgresql
+  - PEEWEE='peewee>=2.3,<2.3.99' DB=mysql
+  - PEEWEE='peewee>=2.4,<2.4.99' DB=postgresql
+  - PEEWEE='peewee>=2.4,<2.4.99' DB=mysql
+  - PONY='pony>=0.5,<0.5.99' DB=postgresql
+  - PONY='pony>=0.5,<0.5.99' DB=mysql
+  - PONY='pony>=0.6,<0.6.99' DB=postgresql
+  - PONY='pony>=0.6,<0.6.99' DB=mysql
+  - SQLALCHEMY='sqlalchemy>=0.8,<0.8.99' DB=postgresql
+  - SQLALCHEMY='sqlalchemy>=0.8,<0.8.99' DB=mysql
+  - SQLALCHEMY='sqlalchemy>=0.9,<0.9.99' DB=postgresql
+  - SQLALCHEMY='sqlalchemy>=0.9,<0.9.99' DB=mysql
+  - DJANGO='django>=1.4,<1.4.99 DB=postgresql
+  - DJANGO='django>=1.4,<1.4.99' DB=mysql
+  - DJANGO='django>=1.5,<1.5.99' DB=postgresql
+  - DJANGO='django>=1.5,<1.5.99' DB=mysql
+  - DJANGO='django>=1.6,<1.6.99' DB=postgresql
+  - DJANGO='django>=1.6,<1.6.99' DB=mysql
+  - DJANGO='django>=1.7,<1.7.99' DB=postgresql
+  - DJANGO='django>=1.7,<1.7.99' DB=mysql
 matrix:
   fast_finish: true
   exclude:
     - python: 2.6
-      env: DJANGO='django>=1.7.0,<1.8.0' DB=postgresql
+      env: DJANGO='django>=1.7,<1.7.99' DB=postgresql
     - python: 2.6
-      env: DJANGO='django>=1.7.0,<1.8.0' DB=mysql
+      env: DJANGO='django>=1.7,<1.7.99' DB=mysql
     - python: 3.2
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=postgresql
+      env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.2
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=mysql
+      env: DJANGO='django>=1.4,<1.4.99' DB=mysql
     - python: 3.3
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=postgresql
+      env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.3
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=mysql
+      env: DJANGO='django>=1.4,<1.4.99' DB=mysql
     - python: 3.4
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=postgresql
+      env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.4
-      env: DJANGO='django>=1.4.0,<1.5.0' DB=mysql
+      env: DJANGO='django>=1.4,<1.4.99' DB=mysql
     - python: 3.2
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=postgresql
+      env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.2
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=mysql
+      env: PONY='pony>=0.5,<0.5.99' DB=mysql
     - python: 3.3
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=postgresql
+      env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.3
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=mysql
+      env: PONY='pony>=0.5,<0.5.99' DB=mysql
     - python: 3.4
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=postgresql
+      env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.4
-      env: PONY='pony>=0.5.0,<0.6.0,!=0.5.4' DB=mysql
-    - python: 3.2
-      env: PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=postgresql
-    - python 3.2
-      env: PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=mysql
-  allow_failures:
-    - env: PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=postgresql
-    - env: PONY='https://github.com/ponyorm/pony/archive/0.6rc2.tar.gz' DB=mysql
+      env: PONY='pony>=0.5,<0.5.99' DB=mysql
 before_script:
   - if [[ $DB == postgresql ]]; then psql -c 'create database architect;' -U postgres; fi
   - if [[ $DB == mysql ]]; then mysql -e 'create database architect;' -u root; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - SQLALCHEMY='sqlalchemy>=0.8,<0.8.99' DB=mysql
   - SQLALCHEMY='sqlalchemy>=0.9,<0.9.99' DB=postgresql
   - SQLALCHEMY='sqlalchemy>=0.9,<0.9.99' DB=mysql
-  - DJANGO='django>=1.4,<1.4.99 DB=postgresql
+  - DJANGO='django>=1.4,<1.4.99' DB=postgresql
   - DJANGO='django>=1.4,<1.4.99' DB=mysql
   - DJANGO='django>=1.5,<1.5.99' DB=postgresql
   - DJANGO='django>=1.5,<1.5.99' DB=mysql
@@ -51,6 +51,10 @@ matrix:
       env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.2
       env: PONY='pony>=0.5,<0.5.99' DB=mysql
+    - python: 3.2
+      env: PONY='pony>=0.6,<0.6.99' DB=postgresql
+    - python: 3.2
+      env: PONY='pony>=0.6,<0.6.99' DB=mysql
     - python: 3.3
       env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,16 @@ env:
   - SQLALCHEMY='sqlalchemy>=0.9,<0.9.99' DB=mysql
   - DJANGO='django>=1.4,<1.4.99' DB=postgresql
   - DJANGO='django>=1.4,<1.4.99' DB=mysql
+  - DJANGO='django>=1.4,<1.4.99' DB=sqlite
   - DJANGO='django>=1.5,<1.5.99' DB=postgresql
   - DJANGO='django>=1.5,<1.5.99' DB=mysql
+  - DJANGO='django>=1.5,<1.5.99' DB=sqlite
   - DJANGO='django>=1.6,<1.6.99' DB=postgresql
   - DJANGO='django>=1.6,<1.6.99' DB=mysql
+  - DJANGO='django>=1.6,<1.6.99' DB=sqlite
   - DJANGO='django>=1.7,<1.7.99' DB=postgresql
   - DJANGO='django>=1.7,<1.7.99' DB=mysql
+  - DJANGO='django>=1.7,<1.7.99' DB=sqlite
 matrix:
   fast_finish: true
   exclude:
@@ -35,18 +39,26 @@ matrix:
       env: DJANGO='django>=1.7,<1.7.99' DB=postgresql
     - python: 2.6
       env: DJANGO='django>=1.7,<1.7.99' DB=mysql
+    - python: 2.6
+      env: DJANGO='django>=1.7,<1.7.99' DB=sqlite
     - python: 3.2
       env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.2
       env: DJANGO='django>=1.4,<1.4.99' DB=mysql
+    - python: 3.2
+      env: DJANGO='django>=1.4,<1.4.99' DB=sqlite
     - python: 3.3
       env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.3
       env: DJANGO='django>=1.4,<1.4.99' DB=mysql
+    - python: 3.3
+      env: DJANGO='django>=1.4,<1.4.99' DB=sqlite
     - python: 3.4
       env: DJANGO='django>=1.4,<1.4.99' DB=postgresql
     - python: 3.4
       env: DJANGO='django>=1.4,<1.4.99' DB=mysql
+    - python: 3.4
+      env: DJANGO='django>=1.4,<1.4.99' DB=sqlite
     - python: 3.2
       env: PONY='pony>=0.5,<0.5.99' DB=postgresql
     - python: 3.2

--- a/architect/databases/__init__.py
+++ b/architect/databases/__init__.py
@@ -5,7 +5,7 @@ class BasePartition(object):
     """Base partition class. All databases should inherit from it"""
     def __init__(self, **kwargs):
         self.dialect = self.__module__.split('.')[-2]
-        self.database = Database(kwargs['cursor'])
+        self.database = Database(kwargs['cursor'], self.dialect)
         self.column_value = kwargs['column_value']
         self.column_name = kwargs['partition_column']
         self.model = kwargs['model']

--- a/architect/databases/utilities.py
+++ b/architect/databases/utilities.py
@@ -5,8 +5,7 @@ class Database(object):
     """Provides helpers for query execution via database cursor"""
     def __init__(self, cursor, dialect):
         if dialect == 'sqlite':
-            if not cursor.connection.isolation_level:
-                cursor.connection.isolation_level = None
+            cursor.connection.isolation_level = None
         else:
             if not cursor.connection.autocommit:
                 cursor.connection.autocommit = True

--- a/architect/databases/utilities.py
+++ b/architect/databases/utilities.py
@@ -3,9 +3,13 @@ from datetime import date, datetime, timedelta
 
 class Database(object):
     """Provides helpers for query execution via database cursor"""
-    def __init__(self, cursor):
-        if not cursor.connection.autocommit:
-            cursor.connection.autocommit = True
+    def __init__(self, cursor, dialect):
+        if dialect == 'sqlite':
+            if not cursor.connection.isolation_level:
+                cursor.connection.isolation_level = None
+        else:
+            if not cursor.connection.autocommit:
+                cursor.connection.autocommit = True
         self.cursor = cursor
 
     def execute(self, sql):

--- a/tests/models/django.py
+++ b/tests/models/django.py
@@ -7,7 +7,8 @@ from django.conf import settings
 
 databases = {
     'postgresql': {'ENGINE': 'django.db.backends.postgresql_psycopg2', 'NAME': 'architect', 'USER': 'postgres'},
-    'mysql': {'ENGINE': 'django.db.backends.mysql', 'NAME': 'architect', 'USER': 'root'}
+    'mysql': {'ENGINE': 'django.db.backends.mysql', 'NAME': 'architect', 'USER': 'root'},
+    'sqlite': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': './tests/architect.db'}
 }
 
 settings.configure(

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -84,3 +84,33 @@ class MysqlDjangoPartitionTestCase(BaseDjangoPartitionTestCase, unittest.TestCas
             'SELECT * FROM test_rangedateyear WHERE id = %s', [object1.id])[0]
 
         self.assertTrue(object1.name, object2.name)
+
+@unittest.skipUnless(os.environ.get('DB') == 'sqlite', 'Not a SQLite build')
+class SqliteDjangoPartitionTestCase(BaseDjangoPartitionTestCase, unittest.TestCase):
+    def test_range_date_day(self):
+        object1 = RangeDateDay.objects.create(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        object2 = RangeDateDay.objects.raw(
+            'SELECT * FROM test_rangedateday WHERE id = %s', [object1.id])[0]
+
+        self.assertTrue(object1.name, object2.name)
+
+    def test_range_date_week(self):
+        object1 = RangeDateWeek.objects.create(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        object2 = RangeDateWeek.objects.raw(
+            'SELECT * FROM test_rangedateweek WHERE id = %s', [object1.id])[0]
+
+        self.assertTrue(object1.name, object2.name)
+
+    def test_range_date_month(self):
+        object1 = RangeDateMonth.objects.create(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        object2 = RangeDateMonth.objects.raw(
+            'SELECT * FROM test_rangedatemonth WHERE id = %s', [object1.id])[0]
+
+        self.assertTrue(object1.name, object2.name)
+
+    def test_range_date_year(self):
+        object1 = RangeDateYear.objects.create(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        object2 = RangeDateYear.objects.raw(
+            'SELECT * FROM test_rangedateyear WHERE id = %s', [object1.id])[0]
+
+        self.assertTrue(object1.name, object2.name)


### PR DESCRIPTION
Hi there,

In 0.2.0, when experimenting with the new sqlite dummy support, I noticed an issue. I implemented simple Meta Fields in my Model I want to partition.

```
class Event(PartitionableMixin, models.Model):

    class PartitionableMeta:
        partition_type = 'range'
        partition_subtype = 'date'
        partition_range = 'month'
        partition_column = 'timestamp'
...
```

This works fine in when using Postgres (which is in my server environment). When testing locally using Django 1.7.1 and Sqlite3, `architect partition --module my.app.models` would produce:

`Unsupported partition type "range" in model "Event", supported types for "sqlite" database are: range`

I traced this back to `cursor.connection.autocommit` apparently not being available with this backend. Apparently, `isolation_level = None` will do this according to [the docs](https://docs.python.org/2/library/sqlite3.html#connection-objects) . After making the attached changes it appears to work correctly.

I'm not sure how you feel about passing the `dialect`into the Database `__init__`, but it was quick. I will also admit I am a novice with travis and nose, but I attempted to add tests for SQLite+Django to just verify it could call the command without breaking and insert data.

Please let me know your thoughts.

Thanks
Kevin