### PR TITLE
Added in small tutorial for doing an AppConfig

### DIFF
--- a/docs/features/partition/index.rst
+++ b/docs/features/partition/index.rst
@@ -54,6 +54,40 @@ After the feature has been installed into the model, run the following console c
 
    $ architect partition --module path.to.the.model.module
 
+.. note::
+   You can optionally setup an AppConfig in Django to automatically run architect partition after any migrations.
+   
+   .. code-block:: python
+      from architect.commands import partition
+
+      from django.apps import AppConfig
+      from django.db import ProgrammingError
+      from django.db.models.signals import post_migrate
+
+      def create_partitions(sender, **kwargs):
+         """
+         After running migrations, go through each of the models in the app and ensure the partitions have been setup.
+         """
+         paths = {model.__module__ for model in sender.get_models()}
+         for path in paths:
+            try:
+               partition.run(dict(module=path))
+            except ProgrammingError:
+               # Possibly because models were just un-migrated or fields have been changed that effect Architect.
+               print("Unable to apply partitions for module '{}'".format(path))
+            else:
+               print("Applied partitions for module '{}'".format(path))
+
+
+      class DemoConfig(AppConfig):
+         name = 'apps.demo'
+
+         def ready(self):
+            super(DemoConfig, self).ready()
+            # Hook up Architect to the post migrations signal
+            post_migrate.connect(create_partitions, sender=self)
+
+
 That's it. Now, when a new record will be inserted, a value from column, specified in the ``column``
 option will be used to determine into what partition the data should be saved. Keep in mind that if
 new partitioned models are added or any settings are changed in existing partitioned models, the


### PR DESCRIPTION
The ability to automatically add in the partitions upon migrations potentially saves a lot of work. Here is a quick how-to for adding in an AppConfig that describes how to run this automatically.

I am not familiar with read the docs so if there is any unsupported syntax in there please advise and I will update. Thanks!