### PR TITLE
improved support for Django 1.6.1

### DIFF
--- a/architect/orms/django/__init__.py
+++ b/architect/orms/django/__init__.py
@@ -1,9 +1,13 @@
 def init():
     import os
+    from distutils.version import StrictVersion
 
     if 'DJANGO_SETTINGS_MODULE' in os.environ:
         try:
             import django
-            django.setup()
+            if StrictVersion(django.get_version()) < StrictVersion('1.7.0'):
+                from django.conf import settings
+            else:
+                django.setup()
         except AttributeError:
             pass


### PR DESCRIPTION
Django 1.6 does not have the setup function.

That fixed architect for projects that uses Django 1.6.1. 
