### PR TITLE
Use CREATE TABLE IF NOT EXISTS in Postgres insert trigger

### DIFF
--- a/architect/databases/postgresql/partition.py
+++ b/architect/databases/postgresql/partition.py
@@ -45,18 +45,14 @@ class Partition(BasePartition):
                         {variables}
                     END IF;
 
-                    IF NOT EXISTS(
-                        SELECT 1 FROM information_schema.tables WHERE table_name=tablename)
-                    THEN
-                        BEGIN
-                            EXECUTE 'CREATE TABLE ' || tablename || ' (
-                                CHECK (' || checks || '),
-                                LIKE "{{parent_table}}" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES
-                            ) INHERITS ("{{parent_table}}");';
-                        EXCEPTION WHEN duplicate_table THEN
-                            -- pass
-                        END;
-                    END IF;
+                    BEGIN
+                        EXECUTE 'CREATE TABLE IF NOT EXISTS ' || tablename || ' (
+                            CHECK (' || checks || '),
+                            LIKE "{{parent_table}}" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES
+                        ) INHERITS ("{{parent_table}}");';
+                    EXCEPTION WHEN duplicate_table THEN
+                        -- pass
+                    END;
 
                     EXECUTE 'INSERT INTO ' || tablename || ' VALUES (($1).*);' USING NEW;
                     RETURN NEW;


### PR DESCRIPTION
As mentioned in #43 , I try to use `CREATE TABLE IF NOT EXISTS` to replace `SELECT THEN CREATE TABLE` for accelerating insert action.

I made a simple test on [architect-pg-test](https://github.com/soyking/architect-pg-test), and got some results running on my computer. But I am not sure whether it is reasonable enough to prove that. 