### PR TITLE
Support table names with hyphens

### DIFF
--- a/architect/databases/postgresql/partition.py
+++ b/architect/databases/postgresql/partition.py
@@ -15,13 +15,19 @@ from ...exceptions import (
 )
 
 
+# Maximum table length must be smaller as the SQL functions and triggers add
+# more characters for their identifiers
+MAX_IDENTIFIER_LENGTH = 63
+MAX_TABLE_LENGTH = MAX_IDENTIFIER_LENGTH - 25
+
+
 class Partition(BasePartition):
     @property
     def safe_tablename(self):
         safe_table = self.table
 
-        if len(safe_table) > 50 or '-' in safe_table:
-            safe_table = 'tbl_{}'.format(hashlib.md5(safe_table).hexdigest())
+        if len(safe_table) > MAX_TABLE_LENGTH or '-' in safe_table:
+            safe_table = 'tbl_{}'.format(hashlib.md5(safe_table.encode('utf-8')).hexdigest())
 
         return safe_table
 

--- a/tests/models/sqlalchemy.py
+++ b/tests/models/sqlalchemy.py
@@ -34,6 +34,18 @@ for database in test_databases:
         }))
 
     if database == 'pgsql':
+        # Use a table name with a hyphen
+        name = '{0}RangeHyphenDateDay'.format(dbname)
+        partition = install(
+            'partition', type='range', subtype='date', constraint='day', column='created', db=engine.url)
+
+        locals()[name] = partition(type(name, (Base,), {
+            '__tablename__': 'test_range-dateday',
+            'id': Column(Integer, primary_key=True),
+            'name': Column(String(length=255)),
+            'created': Column(DateTime, nullable=True)
+        }))
+
         # Generation of entities for integer range partitioning
         for item in ('2', '5'):
             name = '{0}RangeInteger{1}'.format(dbname, item)

--- a/tests/models/sqlalchemy.py
+++ b/tests/models/sqlalchemy.py
@@ -34,6 +34,18 @@ for database in test_databases:
         }))
 
     if database == 'pgsql':
+        # Use a very long table name
+
+        name = '{0}RangeVeryLongDateDay'.format(dbname)
+        partition = install(
+            'partition', type='range', subtype='date', constraint='day', column='created', db=engine.url)
+
+        locals()[name] = partition(type(name, (Base,), {
+            '__tablename__': 'test_rangedatedaywithaverylongtablenamethatwillgooverpostgreslimitations'[:63],
+            'id': Column(Integer, primary_key=True),
+            'name': Column(String(length=255)),
+            'created': Column(DateTime, nullable=True)
+        }))
         # Use a table name with a hyphen
         name = '{0}RangeHyphenDateDay'.format(dbname)
         partition = install(

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -363,6 +363,17 @@ class PostgresqlSqlAlchemyPartitionTestCase(unittest.TestCase):
         self.assertTrue(object1.name, object2.name)
         self.assertTrue(object3.name, object4.name)
 
+    def test_range_date_day_hyphen(self):
+        object1 = PgsqlRangeHyphenDateDay(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        self.session.add(object1)
+        self.session.commit()
+
+        object2 = self.session.query(PgsqlRangeHyphenDateDay).from_statement(
+            text('SELECT * FROM "test_range-dateday_y2014d105" WHERE id = :id')
+        ).params(id=object1.id).first()
+
+        self.assertTrue(object1.name, object2.name)
+
 
 @unittest.skipUnless(os.environ['DB'] in ('mysql', 'all'), 'Not a MySQL build')
 class MysqlSqlAlchemyPartitionTestCase(unittest.TestCase):

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -369,10 +369,27 @@ class PostgresqlSqlAlchemyPartitionTestCase(unittest.TestCase):
         self.session.commit()
 
         object2 = self.session.query(PgsqlRangeHyphenDateDay).from_statement(
-            text('SELECT * FROM "test_range-dateday_y2014d105" WHERE id = :id')
+            text('SELECT * FROM "tbl_667814817492d1843c9d91d06f3555c5_y2014d105" WHERE id = :id')
         ).params(id=object1.id).first()
 
         self.assertTrue(object1.name, object2.name)
+
+    def test_range_date_day_long_tablename(self):
+        object1 = PgsqlRangeVeryLongDateDay(name='foo', created=datetime.datetime(2014, 4, 15, 18, 44, 23))
+        self.session.add(object1)
+        self.session.commit()
+
+        object2 = self.session.query(PgsqlRangeVeryLongDateDay).from_statement(
+            text('SELECT * FROM test_rangedatedaywithaverylongtablenamethatwillgooverpostgresli WHERE id = :id')
+        ).params(id=object1.id).first()
+
+        self.assertTrue(object1.name, object2.name)
+
+        object3 = self.session.query(PgsqlRangeVeryLongDateDay).from_statement(
+            text('SELECT * FROM tbl_3f7c1ccefeb59607865dd3df476eba1f_y2014d105 WHERE id = :id')
+        ).params(id=object1.id).first()
+
+        self.assertTrue(object1.name, object3.name)
 
 
 @unittest.skipUnless(os.environ['DB'] in ('mysql', 'all'), 'Not a MySQL build')


### PR DESCRIPTION
Currently only tested for postgres and SQLAlchemy. I'm not familiar with the MySQL syntax for this type of fix. Also it's a hard to hit this in django (unless you specify custom table names). Not sure about the other ORMs.

Similar fix as https://github.com/maxtepkeev/architect/commit/e6fc9cd9923a7c5d68b53fe9abc943fe29f45b3f

Happy to change some of this up. Replacing the - with _ for the function name feels particularly hacky, but wasn't sure of a better convention to follow