### PR TITLE
Not caching the creation of a cursor

### DIFF
--- a/architect/orms/django/features.py
+++ b/architect/orms/django/features.py
@@ -20,7 +20,7 @@ class ConnectionMixin(object):
     def database(self):
         return self.options.get('db', router.db_for_write(self.model_cls))
 
-    @cached_property
+    @property
     def connection(self):
         db = self.database
 


### PR DESCRIPTION
This gives problems if you have more than 1 connection in your DATABASES variable in settings.py.
The cursor will be closed and give a "cursor already closed" error.