### PR TITLE
Unquoted identifiers are case insensitive #58

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Unreleased
+++++++++++++++++++
+
+- Fixed: PostgreSQL: `Issue #58 <https://github.com/maxtepkeev/architect/issues/58>`__  Unquoted function
+  name are case insensitive and always lowercase
+
 0.5.6 (2017-05-01)
 ++++++++++++++++++
 

--- a/architect/databases/postgresql/partition.py
+++ b/architect/databases/postgresql/partition.py
@@ -66,7 +66,7 @@ class Partition(BasePartition):
                 SELECT 1
                 FROM information_schema.triggers
                 WHERE event_object_table = '{{parent_table}}'
-                AND trigger_name = 'before_insert_{{parent_table}}_trigger'
+                AND trigger_name = LOWER('before_insert_{{parent_table}}_trigger')
             ) THEN
                 CREATE TRIGGER before_insert_{{parent_table}}_trigger
                     BEFORE INSERT ON "{{parent_table}}"
@@ -90,7 +90,7 @@ class Partition(BasePartition):
                 SELECT 1
                 FROM information_schema.triggers
                 WHERE event_object_table = '{{parent_table}}'
-                AND trigger_name = 'after_insert_{{parent_table}}_trigger'
+                AND trigger_name = LOWER('after_insert_{{parent_table}}_trigger')
             ) THEN
                 CREATE TRIGGER after_insert_{{parent_table}}_trigger
                     AFTER INSERT ON "{{parent_table}}"


### PR DESCRIPTION
Unquoted identifiers are case insensitive. Therefore:

```sql
CREATE TRIGGER after_insert_NAME_trigger
AFTER INSERT ON "parent_table1"
FOR EACH ROW EXECUTE PROCEDURE parent_table1_delete_master();
```

Trigger name always lowercase