### PR TITLE
import fix for django3.1

### DIFF
--- a/architect/orms/django/features.py
+++ b/architect/orms/django/features.py
@@ -4,7 +4,7 @@ Defines features for the Django ORM.
 
 from django.conf import settings
 from django.db import router, connections, transaction
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.db.utils import ConnectionDoesNotExist
 from django.utils.functional import cached_property
 


### PR DESCRIPTION
`FieldDoesNotExist` is removed from `django.db.models.fields` in django3.1. 

```python
# When the _meta object was formalized, this exception was moved to
# django.core.exceptions. It is retained here for backwards compatibility
# purposes.
from django.core.exceptions import FieldDoesNotExist
```